### PR TITLE
RELEASE: 4.10.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='online-judge-verify-helper',
-    version='4.9.2',
+    version='4.10.0',
     author='Kimiyuki Onaka',
     author_email='kimiyuki95@gmail.com',
     url='https://github.com/kmyk/online-judge-verify-helper',


### PR DESCRIPTION
- #236 support Nim (@chaemon)
- #239 fix the bug that `oj-verify` crashes when there are files whose `#include` directives are broken
- #238 add `.gitignore` to `.verify-helper/.gitignore`
- #237 add a workaround for a bug of installation of online-judge-tools

---

非自明な変更がそこそこあるので `master` で止めたまま1日ぐらい様子見したい。
@beet-aizu そちらでしばらく使ってみて壊れてなさそうだったらマージしてください