### PR TITLE
Use -Wl,-stack_size,0x10000000 on macOS

### DIFF
--- a/onlinejudge_verify/languages/cplusplus.py
+++ b/onlinejudge_verify/languages/cplusplus.py
@@ -86,6 +86,8 @@ class CPlusPlusLanguage(Language):
 
     def _list_environments(self) -> List[CPlusPlusLanguageEnvironment]:
         default_CXXFLAGS = ['--std=c++17', '-O2', '-Wall', '-g']
+        if platform.system() == 'Darwin':
+            default_CXXFLAGS.append('-Wl,-stack_size,0x10000000')
         if platform.uname().system == 'Linux' and 'Microsoft' in platform.uname().release:
             default_CXXFLAGS.append('-fsplit-stack')
 


### PR DESCRIPTION
## 概要

#234 の修正です.

* macOSで実行する際のコンパイラオプションに`-Wl,-stack_size,0x10000000`を追加しました.
* 修正前はREだったものが, 修正後は通ったことを確認しました.

## 参考

yosupo06/library-checker-problems#85