### PR TITLE
RELEASE: 4.12.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='online-judge-verify-helper',
-    version='4.12.0',
+    version='4.12.1',
     author='Kimiyuki Onaka',
     author_email='kimiyuki95@gmail.com',
     url='https://github.com/kmyk/online-judge-verify-helper',


### PR DESCRIPTION
- #281 fix the bug that sometimes we cannot compile the generated codes of `oj-bundle` on Windows  (pull requested by @jellc)
- #283 enable to include non-standard system headers like `ext/*` or `tr1/*` (pull requested by @jellc)