### PR TITLE
Update LICENSE for removal of docs.py

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 kimiyuki, tsutaj, beet
+Copyright (c) 2019 Kimiyuki Onaka
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
`docs.py` が消えたので表記を単純にしておく
＠beet-aizu @tsutaj 確認たのむ