### PR TITLE
Use site.github.url params in HTML for Jekyll

### DIFF
--- a/onlinejudge_verify_resources/_includes/document_body.html
+++ b/onlinejudge_verify_resources/_includes/document_body.html
@@ -2,7 +2,7 @@
     <h2>Depends on</h2>
     <ul>
     {% for item in page.data.extendedDependsOn %}
-        <li><a href="/{{ item.path }}">{{ item.icon }} {{ item.title }}
+        <li><a href="{{ site.github.url }}/{{ item.path }}">{{ item.icon }} {{ item.title }}
             {% if item.title != item.path %}<small>({{ item.path }})</small>{% endif %}
         </a></li>
     {% endfor %}
@@ -14,7 +14,7 @@
     <h2>Required by</h2>
     <ul>
     {% for item in page.data.extendedRequiredBy %}
-        <li><a href="/{{ item.path }}">{{ item.icon }} {{ item.title }}
+        <li><a href="{{ site.github.url }}/{{ item.path }}">{{ item.icon }} {{ item.title }}
             {% if item.title != item.path %}<small>({{ item.path }})</small>{% endif %}
         </a></li>
     {% endfor %}
@@ -26,7 +26,7 @@
     <h2>Verified with</h2>
     <ul>
     {% for item in page.data.extendedVerifiedWith %}
-        <li><a href="/{{ item.path }}">{{ item.icon }} {{ item.title }}
+        <li><a href="{{ site.github.url }}/{{ item.path }}">{{ item.icon }} {{ item.title }}
             {% if item.title != item.path %}<small>({{ item.path }})</small>{% endif %}
         </a></li>
     {% endfor %}

--- a/onlinejudge_verify_resources/_includes/document_footer.html
+++ b/onlinejudge_verify_resources/_includes/document_footer.html
@@ -1,1 +1,1 @@
-<a href="/">Back to top page</a>
+<a href="{{ site.github.url }}/">Back to top page</a>

--- a/onlinejudge_verify_resources/_includes/toppage_body.html
+++ b/onlinejudge_verify_resources/_includes/toppage_body.html
@@ -4,7 +4,7 @@
     <h3>{{ category.name }}</h3>
     <ul>
         {% for item in category.pages %}
-        <li><a href="/{{ item.path }}">{{ item.icon }} {{ item.title }}
+        <li><a href="{{ site.github.url }}/{{ item.path }}">{{ item.icon }} {{ item.title }}
             {% if item.title != item.path %}<small>({{ item.path }})</small>{% endif %}
         </a></li>
         {% endfor %}
@@ -17,7 +17,7 @@
     <h3>{{ category.name }}</h3>
     <ul>
         {% for item in category.pages %}
-        <li><a href="/{{ item.path }}">{{ item.icon }} {{ item.title }}
+        <li><a href="{{ site.github.url }}/{{ item.path }}">{{ item.icon }} {{ item.title }}
             {% if item.title != item.path %}<small>({{ item.path }})</small>{% endif %}
         </a></li>
         {% endfor %}


### PR DESCRIPTION
`<a href="/xxx">yyy</a>` って書くと壊れるんですよね。CNAME してなければ正解は `<a href="/(ここにリポジトリ名が入る)/xxx">yyy</a>`。`site.github.url` すればよいっぽい