### PR TITLE
Allow .h and .cc for extensions of C++ files, at least for verification

### DIFF
--- a/onlinejudge_verify/languages/list.py
+++ b/onlinejudge_verify/languages/list.py
@@ -21,6 +21,8 @@ def _get_dict() -> Dict[str, Language]:
         _dict = {}
         _dict['.cpp'] = CPlusPlusLanguage()
         _dict['.hpp'] = _dict['.cpp']
+        _dict['.cc'] = _dict['.cpp']
+        _dict['.h'] = _dict['.cpp']
         _dict['.csx'] = CSharpScriptLanguage()
         _dict['.nim'] = NimLanguage()
         _dict['.py'] = PythonLanguage()


### PR DESCRIPTION
related #248 
cc @yosupo06 

ドキュメントとかでは微妙に壊れそうだからまだ非推奨レベルのとりあえずな対応です。HTML の中で `ext == ".hpp"` とかしてる箇所あった気がするし