### PR TITLE
Feature/#342

### DIFF
--- a/onlinejudge_bundle/main.py
+++ b/onlinejudge_bundle/main.py
@@ -23,11 +23,12 @@ def main(args: Optional[List[str]] = None) -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument('path', type=pathlib.Path)
     parser.add_argument('-I', metavar='dir', action='append', type=pathlib.Path, dest='iquote', default=[pathlib.Path.cwd()], help='add the directory dir to the list of directories to be searched for header files during preprocessing (default: ".")')
+    parser.add_argument('--expand_acl', action='store_true', dest='expand_acl', default=False, help='if this flag is passed, atcoder library(acl) is expanded')
     parsed = parser.parse_args(args)
 
     language = onlinejudge_verify.languages.list.get(parsed.path)
     assert language is not None
-    sys.stdout.buffer.write(language.bundle(parsed.path, basedir=parsed.iquote[0], options={'include_paths': parsed.iquote}))
+    sys.stdout.buffer.write(language.bundle(parsed.path, basedir=parsed.iquote[0], options={'include_paths': parsed.iquote, 'expand_acl': parsed.expand_acl}))
 
 
 if __name__ == "__main__":

--- a/onlinejudge_verify/languages/cplusplus.py
+++ b/onlinejudge_verify/languages/cplusplus.py
@@ -189,8 +189,10 @@ class CPlusPlusLanguage(Language):
     def bundle(self, path: pathlib.Path, *, basedir: pathlib.Path = pathlib.Path.cwd(), options: Dict[str, Any]) -> bytes:
         include_paths: List[pathlib.Path] = options['include_paths']
         assert isinstance(include_paths, list)
+        expand_acl: bool = options['expand_acl']
+        assert isinstance(expand_acl, bool)
         bundler = Bundler(iquotes=include_paths)
-        bundler.update(path)
+        bundler.update(path, expand_acl)
         return bundler.get()
 
     def list_environments(self, path: pathlib.Path, *, basedir: pathlib.Path) -> List[CPlusPlusLanguageEnvironment]:


### PR DESCRIPTION
@kmyk 

pull requestを作成してみました。

oj-bundle -I [path to acl] --expand_acl
と渡すと#include <atcoder/****>形式のものは再帰的に展開するように変更しました。
フラグなしの実行の場合は挙動が変化しないようにしたつもりです。

フラグをつけた場合は下記の①、②、③、④全てに対して正しく展開されるはずです。(mathを例にしてますが特に意味はないです。）
①#include <atcoder/math>
②#include "atcoder/math"
③#include <atcoder/math.hpp>
④#include "atcoder/math.hpp"

（①、②、③に関してはフラグなしだと展開されない。④に関してはフラグなしだと部分的に展開される。）