### PR TITLE
Suppress the flickering of links of generated documents

### DIFF
--- a/onlinejudge_verify_resources/_includes/theme_fix.html
+++ b/onlinejudge_verify_resources/_includes/theme_fix.html
@@ -11,5 +11,15 @@
         width: calc(100% - 300px);
     }
 }
+a:hover, a:focus {
+    font-weight: normal;
+    text-decoration: underline;
+}
+h1 a:hover {
+    font-weight: bold;
+}
+h1 a:focus {
+    font-weight: bold;
+}
 </style>
 {% endif %}


### PR DESCRIPTION
Our default theme uses `a:hover { font-weight: bold; }` but this changes
the width of texts and breaks the layout. It's annoying.