### PR TITLE
Set timeout for the dependency analysis of Python files

### DIFF
--- a/onlinejudge_verify/languages/python.py
+++ b/onlinejudge_verify/languages/python.py
@@ -2,6 +2,7 @@
 import concurrent.futures
 import functools
 import pathlib
+import platform
 import sys
 import textwrap
 from logging import getLogger
@@ -57,7 +58,11 @@ def _python_list_depending_files(path: pathlib.Path, basedir: pathlib.Path) -> L
     try:
         executor = concurrent.futures.ThreadPoolExecutor()
         future = executor.submit(importlab.graph.ImportGraph.create, env, [str(path)])
-        res_graph = future.result(timeout=1.0)
+        if platform.uname().system == 'Windows':
+            timeout = 5.0  # 1.0 sec causes timeout on CI using Windows
+        else:
+            timeout = 1.0
+        res_graph = future.result(timeout=timeout)
     except concurrent.futures.TimeoutError as e:
         raise RuntimeError(f"Failed to analyze the dependency graph (timeout): {path}") from e
     try:


### PR DESCRIPTION
It's too slow for Python scripts which depends large libraries.
This partially resolves https://github.com/online-judge-tools/verification-helper/issues/308