### PR TITLE
Revert "Fix "View this file on GitHub" links to work even when the default branch is not `master`"

### DIFF
--- a/onlinejudge_verify_resources/_includes/document_header.html
+++ b/onlinejudge_verify_resources/_includes/document_header.html
@@ -3,7 +3,7 @@
 </h1>
 
 <ul>
-    <li><a href="{{ site.github.repository_url }}/blob/{{ site.github.default_branch }}/{{ page.data.path }}">View this file on GitHub</a></li>
+    <li><a href="{{ site.github.repository_url }}/blob/master/{{ page.data.path }}">View this file on GitHub</a></li>
     <li>Last update: {{ page.data.timestamp }}</li>
     {% if page.data.attributes.PROBLEM %}
     <li>Problem: <a href="{{ page.data.attributes.PROBLEM }}">{{ page.data.attributes.PROBLEM }}</a></li>


### PR DESCRIPTION
This reverts commit 5e818f1436c69ddf56156947e1f123b0c25d6683.

試してみたけど動きませんでした