### PR TITLE
EXTERNAL_FAILURE_FLAG を導入

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: 3.x
 
     - name: Install dependencies
       run: pip3 install .[dev]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.x
 
     - name: Install dependencies
       run: pip install .[dev]

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,6 +1,9 @@
 name: verify
 
-on: push
+on:
+  push:
+    branches:
+    - master
 
 jobs:
   verify:
@@ -13,7 +16,7 @@ jobs:
       uses: actions/setup-python@v1
 
     - name: Install dependencies
-      run: pip3 install -U git+https://github.com/online-judge-tools/verification-helper.git@master
+      run: pip3 install -U git+https://github.com/${{ github.repository }}.git@master
 
 
     # required only if you want to verify Haskell code

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+__pycache__

--- a/.verify-helper/docs/static/document.ja.md
+++ b/.verify-helper/docs/static/document.ja.md
@@ -125,6 +125,7 @@ verification_file_suffix = ".test.sed"
 | `PROBLEM` | 提出する問題の URL を指定します | 必須 |
 | `IGNORE` | これが定義されていれば verify は実行されません | `#ifdef __clang__` などで囲った中で指定することで特定の状況下でのみ実行を抑制することができます |
 | `ERROR` | 許容誤差を指定します | |
+| `EXTERNAL_FAILURE_FLAG` | これで指定した環境変数が定義されていなければ verify は成功したものとみなします | ユニットテスト用 |
 
 ## ドキュメント生成
 

--- a/.verify-helper/docs/static/document.md
+++ b/.verify-helper/docs/static/document.md
@@ -124,6 +124,7 @@ Other judging platforms do not currently publish the test cases in usable forms,
 | `PROBLEM` | specify the URL of the problem to submit | required |
 | `IGNORE` | If this is defined in a file, the verification is skipped. | You can use this in a scope like `#ifdef __clang__` to ignore in a specific environment. |
 | `ERROR` | specify the absolute or relative error to be considered as correct | |
+| `EXTERNAL_FAILURE_FLAG` | specify the environment variable name defined only when unit tests fail | for unit test |
 
 ## Generating Documentation
 

--- a/examples/debug/external_failure_flag.test.cpp
+++ b/examples/debug/external_failure_flag.test.cpp
@@ -1,0 +1,5 @@
+#define EXTERNAL_FAILURE_FLAG FAILURE_EXAMPLE
+
+int f() {
+    return 1;
+}

--- a/onlinejudge_verify/documentation/type.py
+++ b/onlinejudge_verify/documentation/type.py
@@ -29,6 +29,7 @@ class SourceCodeStat(NamedTuple):
 
 
 class FrontMatterItem(enum.Enum):
+    # pylint: disable=invalid-name
     title = 'title'
     layout = 'layout'
     documentation_of = 'documentation_of'

--- a/onlinejudge_verify/languages/cplusplus.py
+++ b/onlinejudge_verify/languages/cplusplus.py
@@ -76,6 +76,7 @@ _IGNORE = 'IGNORE'
 _IGNORE_IF_CLANG = 'IGNORE_IF_CLANG'
 _IGNORE_IF_GCC = 'IGNORE_IF_GCC'
 _ERROR = 'ERROR'
+_EXTERNAL_FAILURE_FLAG = 'EXTERNAL_FAILURE_FLAG'
 
 
 # config.toml example:
@@ -153,7 +154,7 @@ class CPlusPlusLanguage(Language):
 
                 # convert macros to attributes
                 if _IGNORE not in macros:
-                    for key in [_PROBLEM, _ERROR]:
+                    for key in [_PROBLEM, _ERROR, _EXTERNAL_FAILURE_FLAG]:
                         if all_ignored:
                             # the first non-ignored environment
                             if key in macros:

--- a/onlinejudge_verify/languages/python.py
+++ b/onlinejudge_verify/languages/python.py
@@ -27,6 +27,7 @@ class PythonLanguageEnvironment(LanguageEnvironment):
             \"\"\"
 
             import os
+            import subprocess
             import sys
 
             # arguments
@@ -39,7 +40,10 @@ class PythonLanguageEnvironment(LanguageEnvironment):
                 env["PYTHONPATH"] = basedir + os.pathsep + env["PYTHONPATH"] 
             else:
                 env["PYTHONPATH"] = basedir  # set `PYTHONPATH` to import files relative to the root directory
-            os.execve(sys.executable, [sys.executable, path], env=env)  # use `os.execve` to avoid making an unnecessary parent process
+            if sys.platform == 'win32':
+                subprocess.run([sys.executable, path], env=env, check=True) # in Windows, exit code of `os.execve` is invalid.
+            else:
+                os.execve(sys.executable, [sys.executable, path], env=env)  # use `os.execve` to avoid making an unnecessary parent process
         """)
         with open(tempdir / 'compiled.py', 'wb') as fh:
             fh.write(code.encode())

--- a/onlinejudge_verify/verify.py
+++ b/onlinejudge_verify/verify.py
@@ -61,6 +61,9 @@ def verify_file(path: pathlib.Path, *, compilers: List[str], tle: float, jobs: i
     except Exception:
         traceback.print_exc()
         return False
+    if 'EXTERNAL_FAILURE_FLAG' in attributes:
+        logger.info('EXTERNAL_FAILURE_FLAG: %s', attributes['EXTERNAL_FAILURE_FLAG'])
+        return attributes['EXTERNAL_FAILURE_FLAG'] not in os.environ
     if 'IGNORE' in attributes:
         return None
 

--- a/onlinejudge_verify/verify.py
+++ b/onlinejudge_verify/verify.py
@@ -119,9 +119,9 @@ def verify_file(path: pathlib.Path, *, compilers: List[str], tle: float, jobs: i
 
 def main(paths: List[pathlib.Path], *, marker: onlinejudge_verify.marker.VerificationMarker, timeout: float = math.inf, tle: float = 60, jobs: int = 1) -> VerificationSummary:
     try:
-        import resource  # pylint: disable=import-outside-toplevel
-        _, hard = resource.getrlimit(resource.RLIMIT_STACK)
-        resource.setrlimit(resource.RLIMIT_STACK, (hard, hard))
+        import resource  # pylint: disable=import-outside-toplevel,import-error
+        _, hard = resource.getrlimit(resource.RLIMIT_STACK) # type: ignore
+        resource.setrlimit(resource.RLIMIT_STACK, (hard, hard)) # type: ignore
     except Exception:
         logger.warning('failed to increase the stack size')
         print('::warning ::failed to ulimit')

--- a/onlinejudge_verify/verify.py
+++ b/onlinejudge_verify/verify.py
@@ -76,7 +76,7 @@ def verify_file(path: pathlib.Path, *, compilers: List[str], tle: float, jobs: i
     directory = pathlib.Path('.verify-helper/cache') / hashlib.md5(url.encode()).hexdigest()
     if not (directory / 'test').exists() or list((directory / 'test').iterdir()) == []:
         directory.mkdir(parents=True, exist_ok=True)
-        exec_command(['sleep', '2'])
+        time.sleep(2)
         command = ['oj', 'download', '--system', '-d', str(directory / 'test'), '--silent', url]
 
         if os.environ.get('DROPBOX_TOKEN'):

--- a/onlinejudge_verify/verify.py
+++ b/onlinejudge_verify/verify.py
@@ -120,8 +120,8 @@ def verify_file(path: pathlib.Path, *, compilers: List[str], tle: float, jobs: i
 def main(paths: List[pathlib.Path], *, marker: onlinejudge_verify.marker.VerificationMarker, timeout: float = math.inf, tle: float = 60, jobs: int = 1) -> VerificationSummary:
     try:
         import resource  # pylint: disable=import-outside-toplevel,import-error
-        _, hard = resource.getrlimit(resource.RLIMIT_STACK) # type: ignore
-        resource.setrlimit(resource.RLIMIT_STACK, (hard, hard)) # type: ignore
+        _, hard = resource.getrlimit(resource.RLIMIT_STACK)  # type: ignore
+        resource.setrlimit(resource.RLIMIT_STACK, (hard, hard))  # type: ignore
     except Exception:
         logger.warning('failed to increase the stack size')
         print('::warning ::failed to ulimit')

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,9 +15,9 @@ classifiers =
 
 [options.extras_require]
 dev =
-    isort == 5.5.2
-    mypy == 0.782
-    pylint == 2.6.0
+    isort == 5.10.1
+    mypy == 0.941
+    pylint == 2.7.3
     yapf == 0.30.0
 
 [yapf]


### PR DESCRIPTION
`oj-verify` 以外のテストケースを使用する場合にはダミーのテストケースの導入が推奨されていますが、C++以外の言語では必ずしもダミーのテストケースにmain関数相当のものを追加できない場合もあるので、`EXTERNAL_FAILURE_FLAG ` の導入を提案します。

仕様
`EXTERNAL_FAILURE_FLAG ` の値として環境変数の名前を渡す。その環境変数が定義されていれば該当ファイルを失敗、定義されていなければ成功として扱う。

用途
GitHub Actions で `oj-verify` と別にユニットテストを実行する。