### PR TITLE
Fix: インクルードガードの前の空行やコメント行を許容するようにしました

### DIFF
--- a/onlinejudge_verify/languages/cplusplus_bundle.py
+++ b/onlinejudge_verify/languages/cplusplus_bundle.py
@@ -346,7 +346,11 @@ class Bundler:
                         continue
 
                 if uncommented_line:
-                    non_guard_line_found = True
+                    if not non_guard_line_found and uncommented_line == b"\n":
+                        # include guard の前がコメントまたは空行の場合は non_guard_line_found を True にしない
+                        pass
+                    else:
+                        non_guard_line_found = True
                     if include_guard_macro is not None and not include_guard_define_found:
                         # 先頭に #ifndef が見付かっても #define が続かないならそれは include guard ではない
                         include_guard_macro = None

--- a/onlinejudge_verify/languages/cplusplus_bundle.py
+++ b/onlinejudge_verify/languages/cplusplus_bundle.py
@@ -308,8 +308,8 @@ class Bundler:
                 if re.match(rb'\s*#\s*pragma\s+once\s*', line):  # #pragma once は comment 扱いで消されてしまう
                     logger.debug('%s: line %s: #pragma once', str(path), i + 1)
                     if non_guard_line_found:
-                        # 先頭以外で #pragma once されてた場合は諦める
-                        raise BundleErrorAt(path, i + 1, "#pragma once found in a non-first line")
+                        # #pragma once の前にコードが書かれていた場合に落とす
+                        raise BundleErrorAt(path, i + 1, "found codes before #pragma once")
                     if include_guard_macro is not None:
                         raise BundleErrorAt(path, i + 1, "#pragma once found in an include guard with #ifndef")
                     if path.resolve() in self.pragma_once:


### PR DESCRIPTION
#219 に対応しています
- 修正に伴って、元のエラーメッセージを、`include guardの外側にコードが書かれていた場合`を参考に変更しましたのでそちらもお時間あればご確認お願いします。