### PR TITLE
Update C# and Go, fix Go tests

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -37,13 +37,15 @@ jobs:
     # required only if you want to verify C# script files
     - uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '3.1.101'
+        dotnet-version: '6.0.413'
     - name: Install dependencies (C#)
-      run: dotnet tool install --global dotnet-script --version 1.4.0
+      run: dotnet tool install --global dotnet-script --version 1.3.0
 
     # required only if you want to verify Go code
     - name: Install dependencies (Go)
       uses: actions/setup-go@v4
+      with:
+        go-version: '1.20.7'
 
     # required only if you want to verify Ruby code
     - name: Install dependencies (Ruby)

--- a/.verify-helper/config.toml
+++ b/.verify-helper/config.toml
@@ -3,3 +3,11 @@ compile = "bash -c 'echo hello > {tempdir}/hello'"
 execute = "env AWKPATH={basedir} awk -f {path}"
 bundle = "false"
 list_dependencies = "sed 's/^@include \"\\(.*\\)\"$/\\1/ ; t ; d' {path}"
+
+[languages.go]
+# Because of Go modules, go run does not work outside a module.
+# With -C option, go run changes directory and executes otherwise normally.
+# We need to add the prefix ../../ because {path} is something like examples/go/helloworld.test.go
+# and the argument is interpreted relative to ./examples/go.
+# -C option is available in Go >=1.20.
+execute = "go run -C ./examples/go ../../{path}"

--- a/examples/go/go.mod
+++ b/examples/go/go.mod
@@ -1,0 +1,3 @@
+module example-go
+
+go 1.20

--- a/examples/go/helloworld.test.go
+++ b/examples/go/helloworld.test.go
@@ -3,10 +3,10 @@
 package main
 
 import (
-    "fmt"
-    "./helloworld"
+	"example-go/helloworld"
+	"fmt"
 )
 
 func main() {
-    fmt.Printf("%s\n", helloworld.GetHelloWorld())
+	fmt.Printf("%s\n", helloworld.GetHelloWorld())
 }


### PR DESCRIPTION
We lock versions for some programming languages (as of 2023-08-11):
|Language|Locked Version|AtCoder ([old judge](https://atcoder.jp/contests/abc313/submit))|AtCoder ([new judge](https://atcoder.jp/contests/newjudge-2308-algorithm))|Codeforces|
|--|--|--|--|--|
|.NET SDK|6.0.413|3.1.201|7.0.7|6.0|
|Go|1.20.7|1.14.1|1.20.6|1.19.5|

Besides, Go's testing is fixed so that it handles Go modules correctly.