### PR TITLE
Use pytest instead of python setup.py

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,8 @@ jobs:
 
     - name: Run tests
       run: |
+        pip install pytest
         unset GITHUB_ACTION
         oj-verify -h
-        python setup.py test
+        pytest
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,6 @@ ENV/
 env.bak/
 venv.bak/
 
+# Python
 __pycache__
+build/


### PR DESCRIPTION
Fix #428.
Fail-fast is also disabled because currently windows-latest and macos-latest both fail and inspecting what causes failure becomes hard if fail-fast is enabled.